### PR TITLE
Datetime

### DIFF
--- a/Applications/code/call_run_for_each_input.m
+++ b/Applications/code/call_run_for_each_input.m
@@ -3,7 +3,6 @@ function call_run_for_each_input(inputI, dataL)
 coreNAME_woL = 'newStack';
 dataL = dataL;
 inputN = inputI;
-r_date = date;
 exactStart = -1;
 target_est = 'step';
 dataNormalize = 0;

--- a/Applications/construct_hmm_stack.m
+++ b/Applications/construct_hmm_stack.m
@@ -22,6 +22,11 @@ save('recordSummary_info.mat', 'inputNAME', 'beginNend')
 
 %% Run the profile-HMM algorithm
 
+% Set `datetime` string
+t = datetime;
+DateStringTest = datestr(t);
+folderDateString = strrep(DateStringTest,' ','_');
+
 cd code
 
 % Criteria of convergence
@@ -29,7 +34,7 @@ iterTol = 0.1;  %% Iteration stops if log likelihood does not increase larger th
 iterMax = 10;   %% Iteration stops if the number of iteration is larget than iterMax.
 
 contiIter = true;
-run_for_communication('newStack', dataL, date, 1, 'step', 0);
+run_for_communication('newStack', dataL, folderDateString, 1, 'step', 0);
 i = 0;
 while contiIter == true
     i = i + 1;
@@ -37,7 +42,7 @@ while contiIter == true
     for inputI = 1 : length(name)
         call_run_for_each_input(inputI, dataL)
     end
-    LL(i) = run_for_communication('newStack', dataL, date, 1, 'step', 0);
+    LL(i) = run_for_communication('newStack', dataL, folderDateString, 1, 'step', 0);
 
     if i ~= 1
         if abs(LL(i)-LL(i-1))/LL(i-1) < iterTol/100

--- a/Applications/construct_hmm_stack.m
+++ b/Applications/construct_hmm_stack.m
@@ -40,7 +40,7 @@ while contiIter == true
     i = i + 1;
     
     for inputI = 1 : length(name)
-        call_run_for_each_input(inputI, dataL)
+        call_run_for_each_input(inputI, dataL, folderDateString)
     end
     LL(i) = run_for_communication('newStack', dataL, folderDateString, 1, 'step', 0);
 


### PR DESCRIPTION
Use of the intrinsic `date` to name and search for the output directory names leads to a crash whenever date changes on the hardware clock.

This issue was encountered during an HPC run. The code ran overnight, and crashed when it tried to probe the previous `date` directory. To circumvent this issue, a string containing the `datetime` during the start of the run is created. This static string a) names the output directory, b) does not change during the run. When the code probes for the previous results' directory, it will correctly find it regardless of the current date.